### PR TITLE
Faster window redrawing by not using .update()

### DIFF
--- a/graphics.py
+++ b/graphics.py
@@ -42,7 +42,7 @@ class Window():
         """Redraws the Window object"""
 
         self.__root.update_idletasks()
-        self.__root.update()
+        # self.__root.update()
         return
 
     def wait_for_close(self) -> None:


### PR DESCRIPTION
This commit comments out `.update()` and only uses `.updateidletasks()`
for redrawing.

Ref: https://stackoverflow.com/a/68974368/10766878
